### PR TITLE
adds support for <simpleion_value>.ion_hash()

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,18 @@ This package is designed to work with **Python 3.4+**.
 
 ## Getting Started
 
-The following Python code calculates a hash for the Ion value `[1, 2, 3]` using the MD5 hash function:
+Computing the Ion hash of a simpleion value may be done by calling the `ion_hash()` method.  For example:
+
+```python
+>>> import amazon.ion.simpleion as ion
+>>> import ionhash
+>>> obj = ion.loads('[1, 2, 3]')
+>>> hash = obj.ion_hash('md5')
+>>> print('digest:', ''.join(' %02x' % x for x in digest))
+digest:  8f 3b f4 b1 93 5c f4 69 c9 c1 0c 31 52 4b 26 25
+```
+
+Alternatively, lower-level hash_reader/hash_writer APIs may be used to compute an Ion hash:
 
 ```python
 from io import BytesIO
@@ -37,7 +48,7 @@ while True:
         break
 
 digest = reader.send(HashEvent.DIGEST)
-print("digest:", ''.join(' %02x' % x for x in digest))
+print('digest:', ''.join(' %02x' % x for x in digest))
 ```
 
 When run, it produces the following output:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,27 @@ ionhash.hasher module
    :undoc-members:
    :show-inheritance:
 
+.. method:: <simpleion_class>.ion_hash(algorithm=None, hash_function_provider=None)
+
+   Given an algorithm or hash_function_provider, computes the Ion hash
+   of this value.
+
+   Args:
+       algorithm:
+           A string corresponding to the name of a hash algorithm supported
+           by the `hashlib` module.
+
+       hash_function_provider:
+           A function that returns a new ``IonHasher`` instance when called.
+
+           Note that multiple ``IonHasher`` instances may be required to hash a single value
+           (depending on the type of the Ion value).
+
+   Returns:
+       `bytes` that represent the Ion hash of this value for the specified algorithm
+       or hash_function_provider.
+
+
 .. autofunction:: ionhash.hasher.hash_reader(reader, hash_function_provider)
 .. autofunction:: ionhash.hasher.hash_writer(writer, hash_function_provider)
 

--- a/ionhash/__init__.py
+++ b/ionhash/__init__.py
@@ -1,0 +1,64 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#  
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from six import BytesIO
+
+from amazon.ion.core import ION_STREAM_END_EVENT
+from amazon.ion.simple_types import _IonNature
+from amazon.ion.simpleion import _dump
+from amazon.ion.writer import blocking_writer
+from amazon.ion.writer_binary import binary_writer
+
+from ionhash.hasher import hashlib_hash_function_provider
+from ionhash.hasher import hash_writer
+from ionhash.hasher import HashEvent
+
+
+# pydoc for this function is DUPLICATED in docs/index.rst
+def ion_hash(self, algorithm=None, hash_function_provider=None):
+    """Given an algorithm or hash_function_provider, computes the Ion hash
+    of this value.
+
+    Args:
+        algorithm:
+            A string corresponding to the name of a hash algorithm supported
+            by the `hashlib` module.
+
+        hash_function_provider:
+            A function that returns a new ``IonHasher`` instance when called.
+
+            Note that multiple ``IonHasher`` instances may be required to hash a single value
+            (depending on the type of the Ion value).
+
+    Returns:
+        `bytes` that represent the Ion hash of this value for the specified algorithm
+        or hash_function_provider.
+    """
+    if algorithm is None and hash_function_provider is None:
+        raise Exception("Either 'algorithm' or 'hash_function_provider' must be specified")
+    if algorithm is not None and hash_function_provider is not None:
+        raise Exception("Either 'algorithm' or 'hash_function_provider' must be specified, not both")
+
+    if algorithm is not None:
+        hfp = hashlib_hash_function_provider(algorithm)
+    else:
+        hfp = hash_function_provider
+
+    hw = hash_writer(blocking_writer(binary_writer(), BytesIO()), hfp)
+    _dump(self, hw)
+    hw.send(ION_STREAM_END_EVENT)
+    return hw.send(HashEvent.DIGEST)
+
+
+_IonNature.ion_hash = ion_hash
+

--- a/ionhash/__init__.py
+++ b/ionhash/__init__.py
@@ -24,7 +24,7 @@ from ionhash.hasher import hash_writer
 from ionhash.hasher import HashEvent
 
 
-# pydoc for this function is DUPLICATED in docs/index.rst
+# pydoc for this method is DUPLICATED in docs/index.rst
 def ion_hash(self, algorithm=None, hash_function_provider=None):
     """Given an algorithm or hash_function_provider, computes the Ion hash
     of this value.
@@ -60,5 +60,6 @@ def ion_hash(self, algorithm=None, hash_function_provider=None):
     return hw.send(HashEvent.DIGEST)
 
 
+# adds the `ion_hash` method to all simpleion value classes:
 _IonNature.ion_hash = ion_hash
 

--- a/ionhash/hasher.py
+++ b/ionhash/hasher.py
@@ -11,7 +11,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-"""Provides readers/writers that hash Ion values according to the Ion Hash Specification."""
+"""Adds an `ion_hash()` method to all simpleion value classes, and provides
+readers/writers that hash Ion values according to the Ion Hash Specification."""
 
 from abc import ABC, abstractmethod
 from functools import cmp_to_key
@@ -45,7 +46,7 @@ class HashEvent(Enum):
 
 
 def hashlib_hash_function_provider(algorithm):
-    """A hash function provider based on hashlib."""
+    """A hash function provider based on `hashlib`."""
     def _f():
         return _HashlibHash(algorithm)
     return _f
@@ -67,7 +68,7 @@ class IonHasher(ABC):
 
 
 class _HashlibHash(IonHasher):
-    """Implements the expected hash function methods for the specified algorithm using hashlib."""
+    """Implements the expected hash function methods for the specified algorithm using `hashlib`."""
     def __init__(self, algorithm):
         self._algorithm = algorithm
         self._hasher = hashlib.new(self._algorithm)
@@ -97,7 +98,7 @@ def hash_reader(reader, hash_function_provider):
             An ion-python reader coroutine.
 
         hash_function_provider(function):
-            A function that returns a function that produces ``IonHasher`` instances when called.
+            A function that returns a new ``IonHasher`` instance when called.
 
             Note that multiple ``IonHasher`` instances may be required to hash a single value
             (depending on the type of the Ion value).
@@ -124,7 +125,7 @@ def hash_writer(writer, hash_function_provider):
             An ion-python writer coroutine.
 
         hash_function_provider(function):
-            A function that returns a function that produces ``IonHasher`` instances when called.
+            A function that returns a new ``IonHasher`` instance when called.
 
             Note that multiple ``IonHasher`` instances may be required to hash a single value
             (depending on the type of the Ion value).

--- a/tests/test_ion_hash_tests.py
+++ b/tests/test_ion_hash_tests.py
@@ -48,6 +48,7 @@ def _test_data(algorithm):
 
 
 _IVM = "$ion_1_0 "
+_IVM_BYTES = [0xE0, 0x01, 0x00, 0xEA]
 
 
 def _test_name(ion_test):
@@ -66,7 +67,7 @@ def _to_buffer(ion_test, binary):
         v = ion.dumps(ion_test['ion'], binary=binary)
 
     if '10n' in ion_test:
-        v = bytearray([0xE0, 0x01, 0x00, 0xEA])  # $ion_1_0
+        v = bytearray(_IVM_BYTES)
         for byte in ion_test['10n']:
             v.append(byte)
 
@@ -177,6 +178,25 @@ def test_writer(ion_test):
     _run_test(ion_test,
               _writer_provider(_reader_provider("text"),
                                _to_buffer(ion_test, binary=False)))
+
+
+@pytest.mark.parametrize("ion_test", _test_data("identity"), ids=_test_name)
+def test_simpleion(ion_test):
+    def to_ion_hash(algorithm):
+        if 'ion' in ion_test:
+            value = ion_test['ion']
+
+        if '10n' in ion_test:
+            ba = bytearray(_IVM_BYTES)
+            for byte in ion_test['10n']:
+                ba.append(byte)
+            value = ion.load(BytesIO(ba))
+
+        return value.ion_hash(hash_function_provider=hash_function_provider(algorithm,
+                                                                            _actual_updates,
+                                                                            _actual_digests))
+
+    _run_test(ion_test, to_ion_hash)
 
 
 _actual_updates = []

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -1,0 +1,44 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#  
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import amazon.ion.simpleion as ion
+from .util import hex_string
+
+
+def test_simpleion_invalid_no_params():
+    try:
+        ion.loads('blah').ion_hash()
+        raise Exception("Expected an exception to be raised")
+    except:
+        pass
+
+
+def test_simpleion_invalid_too_many_params():
+    def noop_function():
+        pass
+
+    try:
+        ion.loads('blah').ion_hash("md5", noop_function)
+        raise Exception("Expected an exception to be raised")
+    except:
+        pass
+
+
+def test_simpleion_with_algorithm():
+    assert ion.loads('"hello"').ion_hash("md5") == \
+        b'\x9e\xb1\x12\x17\x8d\xfa\x00\x57\xf7\xdc\x79\x44\x67\x9d\x99\xb8'
+
+
+# remainder of the testing for the ion_hash() extension to simpleion classes is
+# covered by test_ion_hash_tests.test_simpleion
+

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -12,26 +12,21 @@
 # permissions and limitations under the License.
 
 import amazon.ion.simpleion as ion
-from .util import hex_string
+
+from pytest import raises
 
 
 def test_simpleion_invalid_no_params():
-    try:
+    with raises(Exception):
         ion.loads('blah').ion_hash()
-        raise Exception("Expected an exception to be raised")
-    except:
-        pass
 
 
 def test_simpleion_invalid_too_many_params():
     def noop_function():
         pass
 
-    try:
+    with raises(Exception):
         ion.loads('blah').ion_hash("md5", noop_function)
-        raise Exception("Expected an exception to be raised")
-    except:
-        pass
 
 
 def test_simpleion_with_algorithm():


### PR DESCRIPTION
I'd welcome a way to avoid duplicating the pydoc for `ion_hash()`; any thoughts?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
