### PR TITLE
Aligns clob encoding in test_big_list_of_naughty_strings.py with that…

### DIFF
--- a/tests/test_big_list_of_naughty_strings.py
+++ b/tests/test_big_list_of_naughty_strings.py
@@ -64,13 +64,8 @@ class _TestValue:
 
     def clob(self):
         s = self.string()
-        sb = ''
-        for c in s:
-            if ord(c) >= 128:
-                sb += "\\x" + "{0:x}".format(ord(c))
-            else:
-                sb += c
-        return "{{" + sb + "}}"
+        escaped_s = ''.join(u'\\x{0:x}'.format(b) if (b >= 128) else chr(b) for b in s.encode('utf-8'))
+        return u'{{' + escaped_s + u'}}'
 
     def blob(self):
         return "{{" + base64.b64encode(bytes(self.ion, "utf-8")).decode("utf-8") + "}}"


### PR DESCRIPTION
… of ion-hash-java and ion-hash-js

Note that this only changes clob encoding for a set of tests; the reason for this change is to allow hashes (of values containing clobs) from these tests to be compared with those of the other Ion Hash implementations.

Resolves #9.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
