### PR TITLE
Add faster implementation of _IonNature.ion_hash

### DIFF
--- a/ionhash/__init__.py
+++ b/ionhash/__init__.py
@@ -11,14 +11,9 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from six import BytesIO
-
-from amazon.ion.core import ION_STREAM_END_EVENT
 from amazon.ion.simple_types import _IonNature
-from amazon.ion.simpleion import _dump, _FROM_TYPE
-from amazon.ion.writer import blocking_writer
-from amazon.ion.writer_binary import binary_writer
 
+from ionhash.fast_value_hasher import hash_value
 from ionhash.hasher import hashlib_hash_function_provider
 from ionhash.hasher import hash_writer
 from ionhash.hasher import HashEvent
@@ -54,10 +49,7 @@ def ion_hash(self, algorithm=None, hash_function_provider=None):
     else:
         hfp = hash_function_provider
 
-    hw = hash_writer(blocking_writer(binary_writer(), BytesIO()), hfp)
-    _dump(self, hw, _FROM_TYPE)
-    hw.send(ION_STREAM_END_EVENT)
-    return hw.send(HashEvent.DIGEST)
+    return hash_value(self, hfp)
 
 
 # adds the `ion_hash` method to all simpleion value classes:

--- a/ionhash/__init__.py
+++ b/ionhash/__init__.py
@@ -15,8 +15,6 @@ from amazon.ion.simple_types import _IonNature
 
 from ionhash.fast_value_hasher import hash_value
 from ionhash.hasher import hashlib_hash_function_provider
-from ionhash.hasher import hash_writer
-from ionhash.hasher import HashEvent
 
 
 # pydoc for this method is DUPLICATED in docs/index.rst

--- a/ionhash/fast_value_hasher.py
+++ b/ionhash/fast_value_hasher.py
@@ -1,0 +1,99 @@
+from amazon.ion.core import IonType
+from amazon.ion.simple_types import IonPyNull
+
+from functools import cmp_to_key
+
+from ionhash.hasher import _bytearray_comparator, _scalar_or_null_split_parts, _serialize_null, \
+    _UPDATE_SCALAR_HASH_BYTES_JUMP_TABLE, _BEGIN_MARKER, _TQ, _END_MARKER, \
+    _BEGIN_MARKER_BYTE, _END_MARKER_BYTE, _TQ_ANNOTATED_VALUE, _escape, _TQ_SYMBOL_SID0
+
+
+class _IonEventDuck:
+    """Looks like an IonEvent, quacks like an IonEvent...
+    Used for sending scalar values to the existing ion_binary_writer serializers.
+    """
+    def __init__(self, value, ion_type):
+        self.value = value
+        self.ion_type = ion_type
+
+
+# H(value) → h(s(value))
+def hash_value(value, hfp):
+    """An implementation of the [Ion Hash algorithm](https://github.com/amzn/ion-hash/blob/gh-pages/docs/spec.md)
+    for the Ion data model that doesn't instantiate any ion_readers or ion_writers.
+
+    Args:
+        value: the Ion value to hash
+        hfp: hash function provider
+
+    Returns:
+        Ion Hash digest of the given Ion value
+    """
+    hash_fn = hfp()
+    hash_fn.update(serialize_value(value, hfp))
+    return hash_fn.digest()
+
+
+# s(value) → serialized bytes
+def serialize_value(value, hfp):
+    """Transforms an Ion value to its Ion Hash serialized representation.
+
+    Args:
+        value: the Ion value to serialize
+        hfp: hash function provider
+
+    Returns:
+        bytes representing the given Ion value, serialized according to the Ion Hash algorithm
+    """
+    if value.ion_annotations:
+        return _s_annotated_value(value, hfp)
+    else:
+        return _s_value(value, hfp)
+
+
+# s(annotated value) → B || TQ || s(annotation1) || s(annotation2) || ... || s(annotationn) || s(value) || E
+def _s_annotated_value(value, hfp):
+    return _BEGIN_MARKER + _TQ_ANNOTATED_VALUE + b''.join([_write_symbol(a) for a in value.ion_annotations]) \
+           + _s_value(value, hfp) + _END_MARKER
+
+
+# s(struct) → B || TQ || escape(concat(sort(H(field1), H(field2), ..., H(fieldn)))) || E
+# s(list) or s(sexp) → B || TQ || s(value1) || s(value2) || ... || s(valuen)) || E
+# s(scalar) → B || TQ || escape(representation) || E
+def _s_value(value, hfp):
+    ion_type = value.ion_type
+    is_ion_null = isinstance(value, IonPyNull)
+    if ion_type == IonType.STRUCT and not is_ion_null:
+        field_hashes = [_h_field(field_name, field_value, hfp) for [field_name, field_value] in value.iteritems()]
+        field_hashes.sort(key=cmp_to_key(_bytearray_comparator))
+        return _BEGIN_MARKER + bytes([_TQ[IonType.STRUCT]]) + _escape(b''.join(field_hashes)) + _END_MARKER
+    elif ion_type in [IonType.LIST, IonType.SEXP] and not is_ion_null:
+        return _BEGIN_MARKER + bytes([_TQ[ion_type]]) \
+               + b''.join([bytes(serialize_value(child, hfp)) for child in value]) + _END_MARKER
+    else:
+        serializer = _serialize_null if is_ion_null else _UPDATE_SCALAR_HASH_BYTES_JUMP_TABLE[ion_type]
+        scalar_bytes = serializer(_IonEventDuck(None if is_ion_null else value, ion_type))
+        [tq, representation] = _scalar_or_null_split_parts(ion_type, scalar_bytes)
+        if len(representation) == 0:
+            return bytes([_BEGIN_MARKER_BYTE, tq, _END_MARKER_BYTE])
+        else:
+            return b''.join([_BEGIN_MARKER, bytes([tq]), _escape(representation), _END_MARKER])
+
+
+# H(field) → h(s(fieldname) || s(fieldvalue))
+def _h_field(field_name, field_value, hfp):
+    hash_fn = hfp()
+    hash_fn.update(_write_symbol(field_name) + serialize_value(field_value, hfp))
+    return hash_fn.digest()
+
+
+# Function for writing symbol tokens (annotations and field names)
+# Has simplified logic compared to regular function because we can make some assumptions about it
+# Namely, that this value does not have annotations, it is always type "symbol"
+def _write_symbol(text_or_symbol_token):
+    text = getattr(text_or_symbol_token, 'text', text_or_symbol_token)
+    if text is None:
+        return bytes([_BEGIN_MARKER_BYTE, _TQ_SYMBOL_SID0, _END_MARKER_BYTE])
+    else:
+        return _BEGIN_MARKER + bytes([_TQ[IonType.SYMBOL]]) \
+               + _escape(bytearray(text, encoding="utf-8")) + _END_MARKER

--- a/ionhash/hasher.py
+++ b/ionhash/hasher.py
@@ -475,19 +475,12 @@ def _bytearray_comparator(a, b):
 def _escape(_bytes):
     """If _bytes contains one or more BEGIN_MARKER_BYTEs, END_MARKER_BYTEs, or ESCAPE_BYTEs,
     returns a new bytearray with such bytes preceeded by a ESCAPE_BYTE;  otherwise, returns
-    the original _bytes unchanged."
+    the original _bytes unchanged.
     """
-    for b in _bytes:
-        if b == _BEGIN_MARKER_BYTE or b == _END_MARKER_BYTE or b == _ESCAPE_BYTE:
-            # found a byte that needs to be escaped;  build a new byte array that
-            # escapes that byte as well as any others
-            escaped_bytes = bytearray()
-            for c in _bytes:
-                if c == _BEGIN_MARKER_BYTE or c == _END_MARKER_BYTE or c == _ESCAPE_BYTE:
-                    escaped_bytes.append(_ESCAPE_BYTE)
-                escaped_bytes.append(c)
-            return escaped_bytes
-
+    if _BEGIN_MARKER_BYTE in _bytes or _END_MARKER_BYTE in _bytes or _ESCAPE_BYTE in _bytes:
+        return _bytes.replace(bytes([_ESCAPE_BYTE]), bytes([_ESCAPE_BYTE, _ESCAPE_BYTE])) \
+                     .replace(_BEGIN_MARKER, bytes([_ESCAPE_BYTE, _BEGIN_MARKER_BYTE])) \
+                     .replace(_END_MARKER, bytes([_ESCAPE_BYTE, _END_MARKER_BYTE]))
     # no escaping needed, return the original _bytes
     return _bytes
 

--- a/tests/test_ion_hash_tests.py
+++ b/tests/test_ion_hash_tests.py
@@ -196,14 +196,14 @@ def test_simpleion(ion_test):
                                                                             _actual_updates,
                                                                             _actual_digests))
 
-    _run_test(ion_test, to_ion_hash)
-
+    # Do not assert on expected_updates because the implementation of ion_hash() is not backed by an ion_writer
+    _run_test(ion_test, to_ion_hash, should_assert_on_expected_updates=False)
 
 _actual_updates = []
 _actual_digests = []
 
 
-def _run_test(ion_test, digester):
+def _run_test(ion_test, digester, should_assert_on_expected_updates=True):
     expect = ion_test['expect']
     for algorithm in expect:
         expected_updates = []
@@ -211,7 +211,7 @@ def _run_test(ion_test, digester):
         final_digest = None
         for sexp in expect[algorithm]:
             annot = sexp.ion_annotations[0].text
-            if annot == "update":
+            if annot == "update" and should_assert_on_expected_updates:
                 expected_updates.append(sexp_to_bytearray(sexp))
                 pass
             elif annot == "digest":
@@ -224,7 +224,7 @@ def _run_test(ion_test, digester):
 
         actual_digest_bytes = digester(algorithm)
 
-        if len(expected_updates) > 0:
+        if should_assert_on_expected_updates and len(expected_updates) > 0:
             assert _actual_updates == expected_updates
 
         if final_digest is not None:


### PR DESCRIPTION
*Issue #, if available:*

Not necessarily a fix; at least an improvement for #21 

*Description of changes:*

New implementation of `.ion_hash()` that does away with the overhead of instantiating `ion_writer`s. As part of this change, I  improved the performance of the `_escape()` function, which has the side effect of also benefitting the `ion_hash_reader` and the `ion_hash_writer`.

I did some _very_ informal performance testing using [this script](https://gist.github.com/popematt/a847ac825ffb267f115599cc0ec983f9).

```
                      Time to hash single value             Ops/Sec                   Approx
Test Case                 (old)       (new)           (old)             (new)       Improvement
===============================================================================================
ion_hash_python_21     2734.39 μs   389.30 μs      365.71 ops/s      2568.72 ops/s       7x
int                     106.84 μs     9.36 μs     9359.53 ops/s    106820.70 ops/s      11x
bool                    100.58 μs     6.17 μs     9942.43 ops/s    162009.17 ops/s      16x
null                     98.02 μs     7.11 μs    10201.86 ops/s    140577.22 ops/s      14x
string                  104.39 μs     7.59 μs     9579.21 ops/s    131760.86 ops/s      14x
decimal                 125.09 μs    16.29 μs     7994.50 ops/s     61396.71 ops/s       8x
clob                    102.30 μs     8.38 μs     9775.37 ops/s    119359.82 ops/s      12x
timestamp               178.36 μs    40.24 μs     5606.68 ops/s     24850.82 ops/s       4x
empty_struct            139.38 μs     7.16 μs     7174.65 ops/s    139569.14 ops/s      19x
struct_one_field        307.97 μs    38.24 μs     3247.12 ops/s     26150.63 ops/s       8x
struct_few_fields       572.92 μs    75.29 μs     1745.44 ops/s     13281.10 ops/s       8x
struct_many_fields     1735.05 μs   329.23 μs      576.35 ops/s      3037.42 ops/s       5x
empty_list              118.40 μs     6.21 μs     8445.82 ops/s    161004.19 ops/s      19x
long_list              2890.12 μs   180.54 μs      346.01 ops/s      5539.09 ops/s      16x
nested_containers       487.38 μs    19.84 μs     2051.80 ops/s     50411.10 ops/s      25x
one_annotation          265.96 μs    11.36 μs     3760.01 ops/s     87993.25 ops/s      23x
many_annotations        506.17 μs    20.03 μs     1975.62 ops/s     49921.85 ops/s      25x
very_long_string        246.75 μs    10.28 μs     4052.64 ops/s     97308.19 ops/s      24x
very_long_blob          304.76 μs    15.67 μs     3281.30 ops/s     63807.71 ops/s      19x

```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
