### PR TITLE
Adds minor optimization to precompute several commonly used byte arrays

### DIFF
--- a/ionhash/fast_value_hasher.py
+++ b/ionhash/fast_value_hasher.py
@@ -87,13 +87,17 @@ def _h_field(field_name, field_value, hfp):
     return hash_fn.digest()
 
 
+# Precomputed bytes for the unknown symbol (sid $0) case of _write_symbol()
+_SERIALIZED_SYMBOL_SID0_BYTES = bytes([_BEGIN_MARKER_BYTE, _TQ_SYMBOL_SID0, _END_MARKER_BYTE])
+
+
 # Function for writing symbol tokens (annotations and field names)
 # Has simplified logic compared to regular function because we can make some assumptions about it
 # Namely, that this value does not have annotations, it is always type "symbol"
 def _write_symbol(text_or_symbol_token):
     text = getattr(text_or_symbol_token, 'text', text_or_symbol_token)
     if text is None:
-        return bytes([_BEGIN_MARKER_BYTE, _TQ_SYMBOL_SID0, _END_MARKER_BYTE])
+        return _SERIALIZED_SYMBOL_SID0_BYTES
     else:
         return _BEGIN_MARKER + bytes([_TQ[IonType.SYMBOL]]) \
                + _escape(bytearray(text, encoding="utf-8")) + _END_MARKER

--- a/ionhash/hasher.py
+++ b/ionhash/hasher.py
@@ -205,6 +205,11 @@ _END_MARKER_BYTE = 0x0E
 _ESCAPE_BYTE = 0x0C
 _BEGIN_MARKER = bytes([_BEGIN_MARKER_BYTE])
 _END_MARKER = bytes([_END_MARKER_BYTE])
+_ESCAPE_MARKER = bytes([_ESCAPE_BYTE])
+_ESCAPED_BEGIN_MARKER = bytes([_ESCAPE_BYTE, _BEGIN_MARKER_BYTE])
+_ESCAPED_END_MARKER = bytes([_ESCAPE_BYTE, _END_MARKER_BYTE])
+_ESCAPED_ESCAPE_MARKER = bytes([_ESCAPE_BYTE, _ESCAPE_BYTE])
+
 
 # Type/Qualifier byte for each Ion type.  This lookup table is used when
 # serializing null.*, container, string, and symbol values.  The TQ byte
@@ -478,9 +483,9 @@ def _escape(_bytes):
     the original _bytes unchanged.
     """
     if _BEGIN_MARKER_BYTE in _bytes or _END_MARKER_BYTE in _bytes or _ESCAPE_BYTE in _bytes:
-        return _bytes.replace(bytes([_ESCAPE_BYTE]), bytes([_ESCAPE_BYTE, _ESCAPE_BYTE])) \
-                     .replace(_BEGIN_MARKER, bytes([_ESCAPE_BYTE, _BEGIN_MARKER_BYTE])) \
-                     .replace(_END_MARKER, bytes([_ESCAPE_BYTE, _END_MARKER_BYTE]))
+        return _bytes.replace(_ESCAPE_MARKER, _ESCAPED_ESCAPE_MARKER) \
+                     .replace(_BEGIN_MARKER, _ESCAPED_BEGIN_MARKER) \
+                     .replace(_END_MARKER, _ESCAPED_END_MARKER)
     # no escaping needed, return the original _bytes
     return _bytes
 


### PR DESCRIPTION
**Issue #, if available:**
Fixes #23 

**Description of changes:**

Precomputes some commonly used `bytes`.  Some very informal performance testing suggests that the `_escape` function has up to a 50% improvement with this change, but the `_escape` function is already pretty fast, so this makes very little difference in the overall performance.

Because of the (modest) improvement gained by precomputing the `bytes` in `_escape`, I also did the same thing to `_write_symbol`.



_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
