### PR TITLE
Fix tests init for Python 3.10

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,7 +15,8 @@ import amazon.ion
 from amazon.ion.core import MultimapValue
 from amazon.ion.simple_types import _ion_type_for
 
-from collections import MutableMapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import MutableMapping
 import six
 
 


### PR DESCRIPTION
*Issue #, if available:*
When trying to run the tests on Python 3.10 you will get an error like:
```
       > ImportError while loading conftest '/build/source/tests/conftest.py'.
       > tests/__init__.py:18: in <module>
       >     from collections import MutableMapping, OrderedDict
       > E   ImportError: cannot import name 'MutableMapping' from 'collections' (/nix/store/7mv9crg6y9bxgn39ynhkkwi3lhhsqhaj-python3-3.10.2/lib/python3.10/collections/__init__.py)
```

This has been deprecated since Python 3.3 and has shown a warning until now when the compatibility is fully removed.

*Description of changes:*
Update the import for `MutableMapping` to new location.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
