### PR TITLE
Remove use of amazon.ion.util.Enum

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.6']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.6']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,6 @@ jobs:
 
       - run: pip install --upgrade setuptools
       - run: pip install -r requirements.txt
-      - run: pip install .
+      - run: pip install -e .
       - run: py.test
       - run: tools/ion-hash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.6']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.6']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/ionhash/hasher.py
+++ b/ionhash/hasher.py
@@ -15,6 +15,7 @@
 readers/writers that hash Ion values according to the Ion Hash Specification."""
 
 from abc import ABC, abstractmethod
+from enum import IntEnum
 from functools import cmp_to_key
 import hashlib
 
@@ -22,7 +23,6 @@ from amazon.ion.core import DataEvent
 from amazon.ion.core import IonEvent
 from amazon.ion.core import IonEventType
 from amazon.ion.core import IonType
-from amazon.ion.util import Enum
 from amazon.ion.util import coroutine
 from amazon.ion.reader import NEXT_EVENT
 from amazon.ion.reader import SKIP_EVENT
@@ -35,7 +35,7 @@ from amazon.ion.writer_binary_raw import _serialize_int
 from amazon.ion.writer_binary_raw import _serialize_timestamp
 
 
-class HashEvent(Enum):
+class HashEvent(IntEnum):
     """Events that may be pushed into a hash_reader or hash_writer coroutine,
     in addition to those allowed by the wrapped reader/writer.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-amazon.ion==0.5.0
+amazon.ion==0.9.0
 py==1.10.0
-pytest==2.9.2
-pytest-runner==2.8
+pytest==6.2.4
+pytest-runner==5.3.1
 setuptools>=65.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ py==1.10.0
 pytest==2.9.2
 pytest-runner==2.8
 setuptools>=65.5.1
-six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ amazon.ion==0.5.0
 py==1.10.0
 pytest==2.9.2
 pytest-runner==2.8
+setuptools>=65.5.1
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ionhash',
-    version='1.3.0-SNAPSHOT',
+    version='1.3.dev',
     description='Python implementation of Amazon Ion Hash',
     url='http://github.com/amzn/ion-hash-python',
     author='Amazon Ion Team',

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,6 @@ setup(
 
     packages=find_packages(exclude=['tests*']),
 
-    install_requires=[
-        'six',
-        'amazon.ion>=0.5',
-    ],
-
     setup_requires=[
         'pytest-runner',
     ],


### PR DESCRIPTION
Replace deprecated custom Enum with Python IntEnum (as of 3.4).
This package is intended to build with 3.4+, so no issue there.

Fixes [GH 32](https://github.com/amazon-ion/ion-hash-python/issues/32)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
